### PR TITLE
Remove 'feManager' from cli_parameters metadata on IR emitting

### DIFF
--- a/model-optimizer/mo/main.py
+++ b/model-optimizer/mo/main.py
@@ -262,6 +262,7 @@ def emit_ir(graph: Graph, argv: argparse.Namespace):
     for_graph_and_each_sub_graph_recursively(graph, RemoveConstOps().find_and_replace_pattern)
     for_graph_and_each_sub_graph_recursively(graph, CreateConstNodesReplacement().find_and_replace_pattern)
 
+    del argv.feManager
     prepare_emit_ir(graph=graph,
                     data_type=graph.graph['cmd_params'].data_type,
                     output_dir=argv.output_dir,


### PR DESCRIPTION
### Details:
 - Otherwise, for current frontends - IR xml fill contain 'fe_manager=..pointer...' in cli_parameters

### Tickets:
 - N/A
