### PR TITLE
CVS-55264: dynamic shape enablement for yolo_box decomposition.

### DIFF
--- a/ngraph/frontend/paddlepaddle/src/op/yolo_box.cpp
+++ b/ngraph/frontend/paddlepaddle/src/op/yolo_box.cpp
@@ -18,37 +18,61 @@ namespace ngraph
                 using namespace opset6;
                 using namespace element;
 
+                // reference
+                // Paddle/python/paddle/fluid/tests/unittests/test_yolo_box_op.py
+                // Paddle/paddle/fluid/operators/detection/yolo_box_op.h
+                // Paddle2ONNX/paddle2onnx/op_mapper/detection/yolo_box.py - clip_bbox is not used
+                // by Paddle2ONNX.
                 NamedOutputs yolo_box(const NodeContext& node_context)
                 {
                     auto data = node_context.get_ng_input("X");
                     auto image_size = node_context.get_ng_input("ImgSize");
 
-                    // TODO: add dynamic shape support - #55264
-                    auto input_shape = data.get_partial_shape();
-                    uint32_t input_height = input_shape[2].get_length();
-                    uint32_t input_width = input_shape[3].get_length();
+                    // get shape of X
+                    auto input_shape = std::make_shared<ShapeOf>(data, i64);
+                    auto indices_batchsize = Constant::create<int32_t>(i64, {1}, {0});
+                    auto indices_height = Constant::create<int32_t>(i64, {1}, {2});
+                    auto indices_width = Constant::create<int64_t>(i64, {1}, {3});
+                    auto const_axis0 = Constant::create<int64_t>(i64, {1}, {0});
+                    auto input_height =
+                        std::make_shared<Gather>(input_shape, indices_height, const_axis0); // H
+                    auto input_width =
+                        std::make_shared<Gather>(input_shape, indices_width, const_axis0); // W
+                    auto batch_size =
+                        std::make_shared<Gather>(input_shape, indices_batchsize, const_axis0); // N
 
                     int32_t class_num = node_context.get_attribute<int32_t>("class_num");
+                    auto const_class_num = Constant::create<int64_t>(i64, {1}, {class_num});
+
                     // PDPD anchors attribute is of type int32. Convert to float for computing
                     // convinient.
                     auto _anchors = node_context.get_attribute<std::vector<int32_t>>("anchors");
                     std::vector<float> anchors(_anchors.begin(), _anchors.end());
-
                     uint32_t num_anchors = anchors.size() / 2;
+                    auto const_num_anchors = Constant::create<int64_t>(i64, {1}, {num_anchors});
 
                     auto default_scale = 1.0f;
                     auto scale_x_y = node_context.get_attribute<float>("scale_x_y", default_scale);
-                    auto downsample_ratio = node_context.get_attribute<int32_t>("downsample_ratio");
-                    auto input_size = input_height * downsample_ratio;
 
-                    std::vector<int64_t> score_shape{
-                        1, input_height * input_width * num_anchors, class_num};
+                    auto downsample_ratio = node_context.get_attribute<int32_t>("downsample_ratio");
+                    auto const_downsample_ratio =
+                        Constant::create<int64_t>(i64, {1}, {downsample_ratio});
+                    auto scaled_input_height =
+                        std::make_shared<Multiply>(input_height, const_downsample_ratio);
+                    auto scaled_input_width =
+                        std::make_shared<Multiply>(input_width, const_downsample_ratio);
+
+                    // score_shape {batch_size, input_height * input_width * num_anchors, class_num}
+                    auto node_mul_whc = std::make_shared<Multiply>(input_height, input_width);
+                    node_mul_whc = std::make_shared<Multiply>(node_mul_whc, const_num_anchors);
+                    auto score_shape = std::make_shared<Concat>(
+                        NodeVector{batch_size, node_mul_whc, const_class_num}, 0);
 
                     auto conf_thresh = node_context.get_attribute<float>("conf_thresh");
-                    std::vector<float> conf_thresh_mat(score_shape[1], conf_thresh);
+                    auto const_conf_thresh = Constant::create<float>(f32, {1}, {conf_thresh});
 
-                    std::cout << "input_height: " << input_height << " input_width: " << input_width
-                              << " input_size: " << input_size << std::endl;
+                    auto clip_bbox = node_context.get_attribute<bool>("clip_bbox");
+
                     std::cout << "num_anchors: " << num_anchors << " scale_x_y: " << scale_x_y
                               << std::endl;
                     std::cout << "downsample_ratio: " << downsample_ratio
@@ -56,32 +80,52 @@ namespace ngraph
                     std::cout << "class_num:  " << class_num << " image_size: " << image_size
                               << std::endl;
 
-                    auto clip_bbox = node_context.get_attribute<bool>("clip_bbox");
-
                     // main X
-                    auto node_x_shape = Constant::create<int64_t>(
-                        i64, {5}, {1, num_anchors, 5 + class_num, input_height, input_width});
+                    // node_x_shape {batch_size, num_anchors, 5 + class_num, input_height,
+                    // input_width}
+                    auto const_class_num_plus5 =
+                        Constant::create<int64_t>(i64, {1}, {5 + class_num});
+                    auto node_x_shape = std::make_shared<Concat>(NodeVector{batch_size,
+                                                                            const_num_anchors,
+                                                                            const_class_num_plus5,
+                                                                            input_height,
+                                                                            input_width},
+                                                                 0);
 
                     auto node_x_reshape = std::make_shared<Reshape>(data, node_x_shape, false);
 
-                    auto node_input_order = Constant::create(i64, {5}, {0, 1, 3, 4, 2});
+                    auto node_input_order = Constant::create<int64_t>(i64, {5}, {0, 1, 3, 4, 2});
                     auto node_x_transpose =
                         std::make_shared<Transpose>(node_x_reshape, node_input_order);
 
                     //  range x/y
-                    std::vector<float> range_x(input_width);
-                    std::iota(range_x.begin(), range_x.end(), 0);
-                    std::vector<float> range_y(input_height);
-                    std::iota(range_y.begin(), range_y.end(), 0);
+                    //  range_x: shape {1, input_width} containing 0...input_width
+                    //  range_y: shape {input_height, 1} containing 0...input_height
+                    auto const_start = Constant::create<float>(f32, {}, {0.f});
+                    auto const_step = Constant::create<float>(f32, {}, {1.f});
+                    auto reduction_axes = Constant::create<int64_t>(i64, {1}, {0});
 
-                    auto node_range_x = Constant::create<float>(f32, {1, range_x.size()}, range_x);
-                    auto node_range_y = Constant::create<float>(f32, {range_y.size(), 1}, range_y);
+                    auto scaler_input_width =
+                        std::make_shared<ReduceMin>(input_width, reduction_axes, false);
+                    auto range_x =
+                        std::make_shared<Range>(const_start, scaler_input_width, const_step, f32);
+                    auto node_range_x = std::make_shared<Unsqueeze>(
+                        range_x, Constant::create<int64_t>(i64, {1}, {0}));
 
-                    auto node_range_x_shape = Constant::create<int64_t>(i64, {2}, {1, input_width});
-                    auto node_range_y_shape =
-                        Constant::create<int64_t>(i64, {2}, {input_height, 1});
+                    auto scaler_input_height =
+                        std::make_shared<ReduceMin>(input_height, reduction_axes, false);
+                    auto range_y =
+                        std::make_shared<Range>(const_start, scaler_input_height, const_step, f32);
+                    auto node_range_y = std::make_shared<Unsqueeze>(
+                        range_y, Constant::create<int64_t>(i64, {1}, {1}));
 
-                    auto node_grid_x = std::make_shared<Tile>(node_range_x, node_range_y_shape);
+                    auto node_range_x_shape = std::make_shared<Concat>(
+                        NodeVector{Constant::create<int64_t>(i64, {1}, {1}), input_width}, 0);
+                    auto node_range_y_shape = std::make_shared<Concat>(
+                        NodeVector{input_height, Constant::create<int64_t>(i64, {1}, {1})}, 0);
+
+                    auto node_grid_x =
+                        std::make_shared<Tile>(node_range_x, node_range_y_shape); // shape (H, W)
                     auto node_grid_y = std::make_shared<Tile>(node_range_y, node_range_x_shape);
 
                     // main X (part2)
@@ -91,7 +135,8 @@ namespace ngraph
                     auto node_split_input = std::make_shared<VariadicSplit>(
                         node_x_transpose, node_split_axis, node_split_lengths);
 
-                    auto node_box_x = node_split_input->output(0);
+                    auto node_box_x =
+                        node_split_input->output(0); // shape (batch_size, num_anchors, H, W, 1)
                     auto node_box_y = node_split_input->output(1);
                     auto node_box_w = node_split_input->output(2);
                     auto node_box_h = node_split_input->output(3);
@@ -135,8 +180,8 @@ namespace ngraph
                     auto node_box_y_add_grid =
                         std::make_shared<Add>(node_grid_y, node_box_y_squeeze);
 
-                    auto node_input_h = Constant::create<float>(f32, {1}, {(float)input_height});
-                    auto node_input_w = Constant::create<float>(f32, {1}, {(float)input_width});
+                    auto node_input_h = std::make_shared<Convert>(input_height, element::f32);
+                    auto node_input_w = std::make_shared<Convert>(input_width, element::f32);
 
                     auto node_box_x_encode =
                         std::make_shared<Divide>(node_box_x_add_grid, node_input_w);
@@ -144,19 +189,23 @@ namespace ngraph
                         std::make_shared<Divide>(node_box_y_add_grid, node_input_h);
 
                     // w/h
-                    auto node_anchor_tensor = Constant::create<float>(
-                        f32, {num_anchors, 2}, anchors); // FIXME:Paddle2ONNX use float!
-
-                    auto node_input_size = Constant::create<float>(f32, {1}, {(float)input_size});
-                    auto node_anchors_div_input_size =
-                        std::make_shared<Divide>(node_anchor_tensor, node_input_size);
-
-                    auto split_axis = Constant::create<int32_t>(i32, {}, {1});
+                    auto node_anchor_tensor =
+                        Constant::create<float>(f32, {num_anchors, 2}, anchors);
+                    auto split_axis = Constant::create<int64_t>(i64, {}, {1});
                     auto node_anchor_split =
-                        std::make_shared<Split>(node_anchors_div_input_size, split_axis, 2);
+                        std::make_shared<Split>(node_anchor_tensor, split_axis, 2);
 
-                    auto node_anchor_w = node_anchor_split->output(0);
-                    auto node_anchor_h = node_anchor_split->output(1);
+                    auto node_anchor_w_origin = node_anchor_split->output(0);
+                    auto node_anchor_h_origin = node_anchor_split->output(1);
+
+                    auto float_input_height =
+                        std::make_shared<Convert>(scaled_input_height, element::f32);
+                    auto node_anchor_h =
+                        std::make_shared<Divide>(node_anchor_h_origin, float_input_height);
+                    auto float_input_width =
+                        std::make_shared<Convert>(scaled_input_width, element::f32);
+                    auto node_anchor_w =
+                        std::make_shared<Divide>(node_anchor_w_origin, float_input_width);
 
                     auto node_new_anchor_shape =
                         Constant::create<int64_t>(i64, {4}, {1, num_anchors, 1, 1});
@@ -180,23 +229,28 @@ namespace ngraph
                     // confidence
                     auto node_conf_sigmoid = std::make_shared<Sigmoid>(node_conf);
 
-                    auto node_conf_thresh = Constant::create<float>(
-                        f32, {1, num_anchors, input_height, input_width, 1}, conf_thresh_mat);
+                    auto node_concat = std::make_shared<Concat>(
+                        NodeVector{Constant::create<int64_t>(i64, {1}, {1}),
+                                   const_num_anchors,
+                                   input_height,
+                                   input_width,
+                                   Constant::create<int64_t>(i64, {1}, {1})},
+                        0);
+                    auto node_conf_thresh = std::make_shared<Broadcast>(
+                        const_conf_thresh,
+                        node_concat); // {1, num_anchors, input_height, input_width, 1}
 
                     auto node_conf_sub =
                         std::make_shared<Subtract>(node_conf_sigmoid, node_conf_thresh);
 
                     auto node_conf_clip = std::make_shared<Clamp>(
-                        node_conf_sub,
-                        0.0f,
-                        std::numeric_limits<float>::max()); // FIXME: PDPD not specify min/max
+                        node_conf_sub, 0.0f, std::numeric_limits<float>::max());
 
                     auto node_zeros = Constant::create<float>(f32, {1}, {0});
                     auto node_conf_clip_bool =
                         std::make_shared<Greater>(node_conf_clip, node_zeros);
 
-                    auto node_conf_clip_cast =
-                        std::make_shared<Convert>(node_conf_clip_bool, f32); // FIMXE: to=1
+                    auto node_conf_clip_cast = std::make_shared<Convert>(node_conf_clip_bool, f32);
 
                     auto node_conf_set_zero =
                         std::make_shared<Multiply>(node_conf_sigmoid, node_conf_clip_cast);
@@ -204,10 +258,17 @@ namespace ngraph
                     /* probability */
                     auto node_prob_sigmoid = std::make_shared<Sigmoid>(node_prob);
 
-                    auto node_new_shape = Constant::create<int64_t>(
-                        i64, {5}, {1, int(num_anchors), input_height, input_width, 1});
-                    auto node_conf_new_shape =
-                        std::make_shared<Reshape>(node_conf_set_zero, node_new_shape, false);
+                    auto node_new_shape = std::make_shared<Concat>(
+                        NodeVector{batch_size,
+                                   const_num_anchors,
+                                   input_height,
+                                   input_width,
+                                   Constant::create<int64_t>(i64, {1}, {1})},
+                        0);
+                    auto node_conf_new_shape = std::make_shared<Reshape>(
+                        node_conf_set_zero,
+                        node_new_shape,
+                        false); // {batch_size, int(num_anchors), input_height, input_width, 1}
 
                     // broadcast confidence * probability of each category
                     auto node_score =
@@ -232,18 +293,21 @@ namespace ngraph
                                                               node_box_h_new_shape},
                                                  4);
 
-                    auto node_conf_cast =
-                        std::make_shared<Convert>(node_conf_bool, f32); // FIMXE: to=1
+                    auto node_conf_cast = std::make_shared<Convert>(node_conf_bool, f32);
 
-                    auto node_pred_box_mul_conf = std::make_shared<Multiply>(
-                        node_pred_box, node_conf_cast); //(1,3,19,19,4) (1,3,19,19,1)
+                    auto node_pred_box_mul_conf =
+                        std::make_shared<Multiply>(node_pred_box, node_conf_cast);
 
-                    auto node_box_shape = Constant::create<int64_t>(
-                        i64, {3}, {1, int(num_anchors) * input_height * input_width, 4});
+                    auto node_box_shape = std::make_shared<Concat>(
+                        NodeVector{
+                            batch_size, node_mul_whc, Constant::create<int64_t>(i64, {1}, {4})},
+                        0);
                     auto node_pred_box_new_shape = std::make_shared<Reshape>(
-                        node_pred_box_mul_conf, node_box_shape, false); //(1,3*19*19,4)
+                        node_pred_box_mul_conf,
+                        node_box_shape,
+                        false); // {batch_size, int(num_anchors) * input_height * input_width, 4}
 
-                    auto pred_box_split_axis = Constant::create<int32_t>(i32, {}, {2});
+                    auto pred_box_split_axis = Constant::create<int32_t>(i64, {}, {2});
                     auto node_pred_box_split =
                         std::make_shared<Split>(node_pred_box_new_shape, pred_box_split_axis, 4);
 
@@ -266,34 +330,37 @@ namespace ngraph
                     auto node_pred_box_y2 = std::make_shared<Add>(node_pred_box_y, node_half_h);
 
                     /* map normalized coords to original image */
-                    auto squeeze_image_size_axes = Constant::create<int64_t>(i64, {1}, {0});
-                    auto node_sqeeze_image_size = std::make_shared<Squeeze>(
-                        image_size, squeeze_image_size_axes); // input ImgSize
+                    auto indices_height_imgsize = Constant::create<int32_t>(i64, {1}, {0});
+                    auto indices_width_imgsize = Constant::create<int64_t>(i64, {1}, {1});
+                    auto const_axis1 = Constant::create<int64_t>(i64, {1}, {1});
+                    auto node_img_height = std::make_shared<Gather>(
+                        image_size, indices_height_imgsize, const_axis1); // shape_image_size[0]
+                    auto node_img_width = std::make_shared<Gather>(
+                        image_size, indices_width_imgsize, const_axis1); // shape_image_size[1]
 
-                    auto image_size_split_axis = Constant::create<int32_t>(i32, {}, {-1});
-                    auto node_image_size_split =
-                        std::make_shared<Split>(node_sqeeze_image_size, image_size_split_axis, 2);
-                    auto node_img_height = node_image_size_split->output(0);
-                    auto node_img_width = node_image_size_split->output(1);
-
-                    auto node_img_width_cast =
-                        std::make_shared<Convert>(node_img_width, f32); // FIMXE: to=1
+                    auto node_img_width_cast = std::make_shared<Convert>(node_img_width, f32);
                     auto node_img_height_cast = std::make_shared<Convert>(node_img_height, f32);
 
-                    auto node_pred_box_x1_decode =
-                        std::make_shared<Multiply>(node_pred_box_x1, node_img_width_cast);
-                    auto node_pred_box_y1_decode =
-                        std::make_shared<Multiply>(node_pred_box_y1, node_img_height_cast);
-                    auto node_pred_box_x2_decode =
-                        std::make_shared<Multiply>(node_pred_box_x2, node_img_width_cast);
-                    auto node_pred_box_y2_decode =
-                        std::make_shared<Multiply>(node_pred_box_y2, node_img_height_cast);
+                    auto squeeze_axes2 = Constant::create<int64_t>(i64, {1}, {2});
+                    auto node_pred_box_x1_reshape = std::make_shared<Squeeze>(
+                        node_pred_box_x1,
+                        squeeze_axes2); // shape (N,C,1) -> (N,C) for upcomping multiply.
+                    auto node_pred_box_y1_reshape =
+                        std::make_shared<Squeeze>(node_pred_box_y1, squeeze_axes2);
+                    auto node_pred_box_x2_reshape =
+                        std::make_shared<Squeeze>(node_pred_box_x2, squeeze_axes2);
+                    auto node_pred_box_y2_reshape =
+                        std::make_shared<Squeeze>(node_pred_box_y2, squeeze_axes2);
 
-                    // reference
-                    // Paddle/python/paddle/fluid/tests/unittests/test_yolo_box_op.py
-                    // Paddle/paddle/fluid/operators/detection/yolo_box_op.h
-                    // Paddle2ONNX/paddle2onnx/op_mapper/detection/yolo_box.py - clip_bbox is not
-                    // used by Paddle2ONNX.
+                    auto node_pred_box_x1_squeeze =
+                        std::make_shared<Multiply>(node_pred_box_x1_reshape, node_img_width_cast);
+                    auto node_pred_box_y1_squeeze =
+                        std::make_shared<Multiply>(node_pred_box_y1_reshape, node_img_height_cast);
+                    auto node_pred_box_x2_squeeze =
+                        std::make_shared<Multiply>(node_pred_box_x2_reshape, node_img_width_cast);
+                    auto node_pred_box_y2_squeeze =
+                        std::make_shared<Multiply>(node_pred_box_y2_reshape, node_img_height_cast);
+
                     std::shared_ptr<ngraph::Node> node_pred_box_result;
                     if (clip_bbox)
                     {
@@ -303,34 +370,52 @@ namespace ngraph
                         auto node_new_img_width =
                             std::make_shared<Subtract>(node_img_width_cast, node_number_one);
                         auto node_pred_box_x2_sub_w = std::make_shared<Subtract>(
-                            node_pred_box_x2_decode, node_new_img_width); // x2 - (w-1)
+                            node_pred_box_x2_squeeze, node_new_img_width); // x2 - (w-1)
                         auto node_pred_box_y2_sub_h = std::make_shared<Subtract>(
-                            node_pred_box_y2_decode, node_new_img_height); // y2 - (h-1)
+                            node_pred_box_y2_squeeze, node_new_img_height); // y2 - (h-1)
 
                         auto max_const = std::numeric_limits<float>::max();
                         auto node_pred_box_x1_clip =
-                            std::make_shared<Clamp>(node_pred_box_x1_decode, 0.0f, max_const);
+                            std::make_shared<Clamp>(node_pred_box_x1_squeeze, 0.0f, max_const);
                         auto node_pred_box_y1_clip =
-                            std::make_shared<Clamp>(node_pred_box_y1_decode, 0.0f, max_const);
+                            std::make_shared<Clamp>(node_pred_box_y1_squeeze, 0.0f, max_const);
                         auto node_pred_box_x2_clip =
                             std::make_shared<Clamp>(node_pred_box_x2_sub_w, 0.0f, max_const);
                         auto node_pred_box_y2_clip =
                             std::make_shared<Clamp>(node_pred_box_y2_sub_h, 0.0f, max_const);
 
                         auto node_pred_box_x2_res = std::make_shared<Subtract>(
-                            node_pred_box_x2_decode, node_pred_box_x2_clip);
+                            node_pred_box_x2_squeeze, node_pred_box_x2_clip);
                         auto node_pred_box_y2_res = std::make_shared<Subtract>(
-                            node_pred_box_y2_decode, node_pred_box_y2_clip);
+                            node_pred_box_y2_squeeze, node_pred_box_y2_clip);
+
+                        auto node_pred_box_x1_clip2 = std::make_shared<Unsqueeze>(
+                            node_pred_box_x1_clip, squeeze_axes2); // reshape back to (N,C,1)
+                        auto node_pred_box_y1_clip2 =
+                            std::make_shared<Unsqueeze>(node_pred_box_y1_clip, squeeze_axes2);
+                        auto node_pred_box_x2_res2 =
+                            std::make_shared<Unsqueeze>(node_pred_box_x2_res, squeeze_axes2);
+                        auto node_pred_box_y2_res2 =
+                            std::make_shared<Unsqueeze>(node_pred_box_y2_res, squeeze_axes2);
 
                         node_pred_box_result =
-                            std::make_shared<Concat>(OutputVector{node_pred_box_x1_clip,
-                                                                  node_pred_box_y1_clip,
-                                                                  node_pred_box_x2_res,
-                                                                  node_pred_box_y2_res},
+                            std::make_shared<Concat>(OutputVector{node_pred_box_x1_clip2,
+                                                                  node_pred_box_y1_clip2,
+                                                                  node_pred_box_x2_res2,
+                                                                  node_pred_box_y2_res2},
                                                      -1); // outputs=node.output('Boxes')
                     }
                     else
                     {
+                        auto node_pred_box_x1_decode = std::make_shared<Unsqueeze>(
+                            node_pred_box_x1_squeeze, squeeze_axes2); // reshape back to (N,C,1)
+                        auto node_pred_box_y1_decode =
+                            std::make_shared<Unsqueeze>(node_pred_box_y1_squeeze, squeeze_axes2);
+                        auto node_pred_box_x2_decode =
+                            std::make_shared<Unsqueeze>(node_pred_box_x2_squeeze, squeeze_axes2);
+                        auto node_pred_box_y2_decode =
+                            std::make_shared<Unsqueeze>(node_pred_box_y2_squeeze, squeeze_axes2);
+
                         node_pred_box_result =
                             std::make_shared<Concat>(OutputVector{node_pred_box_x1_decode,
                                                                   node_pred_box_y1_decode,
@@ -340,10 +425,8 @@ namespace ngraph
                     }
 
                     //
-                    auto node_score_shape =
-                        Constant::create<int64_t>(i64, {score_shape.size()}, score_shape);
                     auto node_score_new_shape = std::make_shared<Reshape>(
-                        node_score, node_score_shape, false); // outputs=node.output('Scores')
+                        node_score, score_shape, false); // outputs=node.output('Scores')
 
                     NamedOutputs outputs;
                     outputs["Boxes"] = {node_pred_box_result};

--- a/ngraph/test/files/paddlepaddle/gen_scripts/generate_yolo_box.py
+++ b/ngraph/test/files/paddlepaddle/gen_scripts/generate_yolo_box.py
@@ -39,27 +39,41 @@ def yolo_box(name : str, x, img_size, attrs : dict):
     return outs
 
 
-def main():
+def TEST1():
     # yolo_box
     pdpd_attrs = {
+            'name': "yolo_box_default",
             'anchors': [10, 13, 16, 30, 33, 23],
             'class_num': 2,
             'conf_thresh': 0.5,
             'downsample_ratio': 32,
-            'clip_bbox': False, #There is bug in Paddle2ONN where clip_bbox is always ignored.
+            'clip_bbox': False,
             'scale_x_y': 1.0
     }
 
     pdpd_attrs_clip_box = {
+        'name': "yolo_box_clip_box",
         'anchors': [10, 13, 16, 30, 33, 23],
         'class_num': 2,
         'conf_thresh': 0.5,
         'downsample_ratio': 32,
-        'clip_bbox': True, #There is bug in Paddle2ONN where clip_bbox is always ignored.
+        'clip_bbox': True,
         'scale_x_y': 1.0
     }
 
-    N = 1
+    pdpd_attrs_scale_xy = {
+        'name': "yolo_box_scale_xy",
+        'anchors': [10, 13, 16, 30, 33, 23],
+        'class_num': 2,
+        'conf_thresh': 0.5,
+        'downsample_ratio': 32,
+        'clip_bbox': True,
+        'scale_x_y': 1.2
+    }
+
+    pdpd_attrs_list = [pdpd_attrs, pdpd_attrs_clip_box, pdpd_attrs_scale_xy]
+    
+    N = 32
     num_anchors = int(len(pdpd_attrs['anchors'])//2)
     x_shape = (N, num_anchors * (5 + pdpd_attrs['class_num']), 13, 13)
     imgsize_shape = (N, 2)
@@ -67,12 +81,34 @@ def main():
     data = np.random.random(x_shape).astype('float32')
     data_ImSize = np.random.randint(10, 20, imgsize_shape).astype('int32') 
 
-    # For any change to pdpd_attrs, do -
-    # step 1. generate paddle model
-    pred_pdpd = yolo_box('yolo_box_test1', data, data_ImSize, pdpd_attrs)
-    pred_pdpd = yolo_box('yolo_box_clip_box', data, data_ImSize, pdpd_attrs_clip_box)
+    for item in pdpd_attrs_list:
+        pred_pdpd = yolo_box(item['name'], data, data_ImSize, item)
 
 
+def TEST2():
+    # yolo_box uneven spatial width and height
+    pdpd_attrs = {
+            'name': "yolo_box_uneven_wh",
+            'anchors': [10, 13, 16, 30, 33, 23],
+            'class_num': 2,
+            'conf_thresh': 0.5,
+            'downsample_ratio': 32,
+            'clip_bbox': False,
+            'scale_x_y': 1.0
+    }
+
+    N = 16
+    SPATIAL_WIDTH = 13
+    SPATIAL_HEIGHT = 9
+    num_anchors = int(len(pdpd_attrs['anchors'])//2)
+    x_shape = (N, num_anchors * (5 + pdpd_attrs['class_num']), SPATIAL_HEIGHT, SPATIAL_WIDTH)
+    imgsize_shape = (N, 2)
+
+    data = np.random.random(x_shape).astype('float32')
+    data_ImSize = np.random.randint(10, 20, imgsize_shape).astype('int32')
+    
+    pred_pdpd = yolo_box(pdpd_attrs['name'], data, data_ImSize, pdpd_attrs)
 
 if __name__ == "__main__":
-    main()     
+    TEST1()
+    TEST2()

--- a/ngraph/test/files/paddlepaddle/models/models.csv
+++ b/ngraph/test/files/paddlepaddle/models/models.csv
@@ -80,4 +80,6 @@ squeeze,
 squeeze_null_axes,
 unsqueeze,
 yolo_box_clip_box,
-yolo_box_test1
+yolo_box_default,
+yolo_box_scale_xy,
+yolo_box_uneven_wh


### PR DESCRIPTION
Details:

    1. dynamic shape enablement for yolo_box decompsition.
    2. fixes for batch_size > 1
    3. fixes when the spacial width of input is not equal to height.
    4. corresponding unit test cases.

Tickets:

    CVS-55264

