### PR TITLE
Make NodeContext independent on DecoderPDPDProto

### DIFF
--- a/ngraph/frontend/paddlepaddle/src/decoder.hpp
+++ b/ngraph/frontend/paddlepaddle/src/decoder.hpp
@@ -17,9 +17,9 @@
 
 #include <paddlepaddle_frontend/frontend.hpp>
 #include <paddlepaddle_frontend/place.hpp>
+#include "node_context.hpp"
 
 #include <ngraph/ngraph.hpp>
-#include <ngraph/opsets/opset6.hpp>
 
 namespace ngraph
 {
@@ -27,7 +27,7 @@ namespace ngraph
     {
         extern std::map<paddle::framework::proto::VarType_Type, ngraph::element::Type> TYPE_MAP;
 
-        class DecoderPDPDProto
+        class DecoderPDPDProto : public pdpd::DecoderBase
         {
         public:
             explicit DecoderPDPDProto(const std::shared_ptr<OpPlacePDPD>& op)
@@ -35,25 +35,14 @@ namespace ngraph
             {
             }
 
-            // TODO: Further populate get_XXX methods on demand
-            std::vector<int32_t> get_ints(const std::string& name,
-                                          const std::vector<int32_t>& def = {}) const;
-            int get_int(const std::string& name, int def = 0) const;
-            std::vector<float> get_floats(const std::string& name,
-                                          const std::vector<float>& def = {}) const;
-            float get_float(const std::string& name, float def = 0.) const;
-            std::string get_str(const std::string& name, const std::string& def = "") const;
-            bool get_bool(const std::string& name, bool def = false) const;
-            std::vector<int64_t> get_longs(const std::string& name,
-                                           const std::vector<int64_t>& def = {}) const;
-            int64_t get_long(const std::string& name, const int64_t& def = {}) const;
+            std::shared_ptr<Variant> get_attribute(const std::string& name,
+                                                   const VariantTypeInfo& type_info) const override;
 
-            ngraph::element::Type get_dtype(const std::string& name,
-                                            ngraph::element::Type def) const;
+            std::vector<pdpd::OutPortName> get_output_names() const override;
 
-            const std::string& get_op_type() const { return op_place->getDesc()->type(); }
-            std::vector<std::string> get_output_names() const;
-            std::vector<element::Type> get_out_port_types(const std::string& port_name) const;
+            ngraph::element::Type get_out_port_type(const std::string& port_name) const override;
+
+            std::string get_op_type() const override;
 
         private:
             std::vector<paddle::framework::proto::OpDesc_Attr>

--- a/ngraph/frontend/paddlepaddle/src/exceptions.cpp
+++ b/ngraph/frontend/paddlepaddle/src/exceptions.cpp
@@ -15,7 +15,7 @@ namespace ngraph
                 OpValidationFailurePDPD::get_error_msg_prefix_pdpd(const pdpd::NodeContext& node)
             {
                 std::stringstream ss;
-                ss << "While validating node '" << node.op_type() << '\'';
+                ss << "While validating node '" << node.get_op_type() << '\'';
                 return ss.str();
             }
         } // namespace pdpd

--- a/ngraph/frontend/paddlepaddle/src/node_context.cpp
+++ b/ngraph/frontend/paddlepaddle/src/node_context.cpp
@@ -1,0 +1,21 @@
+// Copyright (C) 2021 Intel Corporation
+// SPDX-License-Identifier: Apache-2.0
+//
+
+#include "node_context.hpp"
+
+#define NGRAPH_VARIANT_DEFINITION(TYPE)                                                            \
+    constexpr VariantTypeInfo VariantWrapper<TYPE>::type_info;                                     \
+    template class ngraph::VariantImpl<TYPE>;
+
+namespace ngraph
+{
+    NGRAPH_VARIANT_DEFINITION(int32_t)
+    NGRAPH_VARIANT_DEFINITION(std::vector<int32_t>)
+    NGRAPH_VARIANT_DEFINITION(float)
+    NGRAPH_VARIANT_DEFINITION(std::vector<float>)
+    NGRAPH_VARIANT_DEFINITION(bool)
+    NGRAPH_VARIANT_DEFINITION(ngraph::element::Type)
+    NGRAPH_VARIANT_DEFINITION(std::vector<int64_t>)
+
+} // namespace ngraph

--- a/ngraph/frontend/paddlepaddle/src/op/conv2d_utils.cpp
+++ b/ngraph/frontend/paddlepaddle/src/op/conv2d_utils.cpp
@@ -2,6 +2,8 @@
 // SPDX-License-Identifier: Apache-2.0
 //
 
+#include <ngraph/opsets/opset6.hpp>
+
 #include "conv2d_utils.hpp"
 #include "node_context.hpp"
 

--- a/ngraph/frontend/paddlepaddle/src/op/fill_constant_batch_size_like.cpp
+++ b/ngraph/frontend/paddlepaddle/src/op/fill_constant_batch_size_like.cpp
@@ -3,6 +3,7 @@
 //
 
 #include "fill_constant_batch_size_like.hpp"
+#include <ngraph/opsets/opset6.hpp>
 
 namespace ngraph
 {

--- a/ngraph/frontend/paddlepaddle/src/op/matmul.cpp
+++ b/ngraph/frontend/paddlepaddle/src/op/matmul.cpp
@@ -17,8 +17,8 @@ namespace ngraph
                     auto x = node.get_ng_input("X");
                     auto y = node.get_ng_input("Y");
                     auto alpha = node.get_attribute<float>("alpha", 1);
-                    auto transpose_a = node.get_attribute<bool>("transpose_X");
-                    auto transpose_b = node.get_attribute<bool>("transpose_Y");
+                    auto transpose_a = node.get_attribute<bool>("transpose_X", false);
+                    auto transpose_b = node.get_attribute<bool>("transpose_Y", false);
                     auto mm =
                         std::make_shared<ngraph::opset6::MatMul>(x, y, transpose_a, transpose_b);
                     auto alpha_node =

--- a/ngraph/frontend/paddlepaddle/src/op/slice.cpp
+++ b/ngraph/frontend/paddlepaddle/src/op/slice.cpp
@@ -3,6 +3,8 @@
 //
 
 #include "slice.hpp"
+#include <limits.h>
+#include <ngraph/opsets/opset6.hpp>
 
 namespace ngraph
 {

--- a/ngraph/frontend/paddlepaddle/src/op/split.cpp
+++ b/ngraph/frontend/paddlepaddle/src/op/split.cpp
@@ -44,7 +44,7 @@ namespace ngraph
                         if (node.has_ng_input("SectionsTensorList"))
                         {
                             auto inputs = node.get_ng_inputs("SectionsTensorList");
-                            sections_node = std::make_shared<ngraph::opset6::Concat>(inputs, 0);
+                            sections_node = std::make_shared<ngraph::opset7::Concat>(inputs, 0);
                         }
                         else
                         {


### PR DESCRIPTION
### Details:
Introduced 2 versions of get_attribute:
- With default value - will be returned if attribute does not exist
- Without default value - throw exception if attribute does not exist

Some OPs were modified in this case - use 'default' value version instead of 'get_attribute(name)' for some optional parameters


### Tickets:
 - 52247, 52250
